### PR TITLE
improve and simplifying quotes excape

### DIFF
--- a/psu
+++ b/psu
@@ -281,16 +281,9 @@ echo_debug() {
 deploy() {
   # Read docker-compose file content
   local docker_compose_file_content
-  docker_compose_file_content=$(cat "$DOCKER_COMPOSE_FILE")
-
-  # Remove carriage returns
-  docker_compose_file_content="${docker_compose_file_content//$'\r'/''}"
-
-  # Escape double quotes
-  docker_compose_file_content="${docker_compose_file_content//$'"'/'\"'}"
-
-  # Escape newlines
-  docker_compose_file_content="${docker_compose_file_content//$'\n'/'\n'}"
+  docker_compose_file_content="$( jq -Rscjr '{StackFileContent: . }' $DOCKER_COMPOSE_FILE | tail -c +2 | head -c -1 )"
+  echo_debug "DOCKER_COMPOSE_FILE -> $DOCKER_COMPOSE_FILE"
+  echo_debug "docker_compose_file_content -> $docker_compose_file_content"
 
   # If the stack does not exist
   if [ -z "$STACK" ]; then
@@ -324,8 +317,8 @@ deploy() {
       if [ -n "$ENVIRONMENT_VARIABLES_FILE" ]; then
         stack_envvars=$(env_file_to_json)
       fi
-      local data_prefix="{\"Name\":\"$PORTAINER_STACK_NAME\",\"StackFileContent\":\""
-      local data_suffix="\",\"Env\":"$stack_envvars"}"
+      local data_prefix="{\"Name\":\"$PORTAINER_STACK_NAME\","
+      local data_suffix=",\"Env\":"$stack_envvars"}"
       echo "$data_prefix$docker_compose_file_content$data_suffix" > json.tmp
       echo_debug "Stack JSON -> $(echo $data_prefix$docker_compose_file_content$data_suffix | jq -C .)"
 
@@ -354,8 +347,8 @@ deploy() {
       if [ -n "$ENVIRONMENT_VARIABLES_FILE" ]; then
         stack_envvars=$(env_file_to_json)
       fi
-      local data_prefix="{\"Name\":\"$PORTAINER_STACK_NAME\",\"SwarmID\":\"$swarm_id\",\"StackFileContent\":\""
-      local data_suffix="\",\"Env\":"$stack_envvars"}"
+      local data_prefix="{\"Name\":\"$PORTAINER_STACK_NAME\",\"SwarmID\":\"$swarm_id\","
+      local data_suffix=",\"Env\":"$stack_envvars"}"
       echo "$data_prefix$docker_compose_file_content$data_suffix" > json.tmp
       echo_debug "Stack JSON -> $(echo $data_prefix$docker_compose_file_content$data_suffix | jq -C .)"
 
@@ -395,8 +388,8 @@ deploy() {
       new_stack_envvars=$(env_file_to_json)
       stack_envvars="$(echo "${new_stack_envvars}${stack_envvars}" | jq -sjc 'add | unique_by(.name)')"
     fi
-    local data_prefix="{\"Id\":\"$stack_id\",\"StackFileContent\":\""
-    local data_suffix="\",\"Env\":"$stack_envvars",\"Prune\":$PORTAINER_PRUNE}"
+    local data_prefix="{\"Id\":\"$stack_id\","
+    local data_suffix=",\"Env\":"$stack_envvars",\"Prune\":$PORTAINER_PRUNE}"
     echo "$data_prefix$docker_compose_file_content$data_suffix" > json.tmp
     echo_debug "Stack JSON -> $(echo $data_prefix$docker_compose_file_content$data_suffix | jq -C .)"
 


### PR DESCRIPTION
fixing quote excape.
As a test case (in a docker compose) you can try this one

```
version: '3'
services:
  mydb:
    image: mysql:8.0.13
    environment:
      - MYSQL_USER=user
      - MYSQL_PASSWORD=secret
      - MYSQL_ROOT_PASSWORD=password
    entrypoint:
      sh -c "
        echo 'CREATE DATABASE IF NOT EXISTS mydb;     GRANT ALL PRIVILEGES ON mydb.*     TO §uer§@§%§; ' > /docker-entrypoint-initdb.d/init.sql;
        sed -i 's/§/\\d39/g' /docker-entrypoint-initdb.d/init.sql;
        /usr/local/bin/docker-entrypoint.sh --character-set-server=utf8 --collation-server=utf8_unicode_ci --default-authentication-plugin=mysql_native_password
      "
    volumes:
      - mydb:/var/lib/mysql
    ports:
      - "3307:3306"
```