### PR TITLE
List stack with (optional) env variable filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.3] - 2020-05-02
+### Added
+ - Listing stacks
 
 ## [0.1.1] - 2019-06-05
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The provided `psu` script allows to deploy/update/undeploy Portainer stacks. Set
 
 This is particularly useful for CI/CD pipelines using Docker containers.
 
-- `ACTION` ("deploy" or "undeploy", required): Whether to deploy or undeploy the stack
+- `ACTION` ("deploy", "undeploy" or "list", required): Whether to deploy , undeploy or list the stack/s
 - `PORTAINER_USER` (string, required): Username
 - `PORTAINER_PASSWORD` (string, required): Password
 - `PORTAINER_URL` (string, required): URL to Portainer
@@ -72,6 +72,9 @@ This is particularly useful for CI/CD pipelines using Docker containers.
 - `VERBOSE_MODE` ("true" or "false", optional): Whether to activate verbose output mode or not. Defaults to `"false"`. See [verbose mode](#verbose-mode) below.
 - `DEBUG_MODE` ("true" or "false", optional): Whether to activate debug output mode or not. Defaults to `"false"`. See [debug mode](#debug-mode) below.
 - `STRICT_MODE` ("true" or "false", optional): Whether to activate strict mode or not. Defaults to `"false"`. See [strict mode](#strict-mode) below.
+- `LIST_RAW_FORMAT` ("true" or "false", optional): Whether list stacks in raw format or json forma. Defaults to `"false"`. See [list raw mode](#list-in-raw-format) below.
+- `STACK_ENVVAR_NAME` (string, optional): using in action "list" is the name of an evironment variable defined on a stack.
+
 
 #### Examples
 
@@ -97,6 +100,16 @@ export PORTAINER_STACK_NAME="mystack"
 ./psu
 ```
 
+```bash
+export ACTION="list"
+export STACK_ENVVAR_NAME="TAG"
+export PORTAINER_USER="admin"
+export PORTAINER_PASSWORD="password"
+export PORTAINER_URL="http://portainer.local"
+
+./psu
+```
+
 ### With flags
 
 This is more suitable for standalone script usage.
@@ -114,6 +127,8 @@ This is more suitable for standalone script usage.
 - `-v` ("true" or "false", optional): Whether to activate verbose output mode or not. Defaults to `"false"`. See [verbose mode](#verbose-mode) below.
 - `-d` ("true" or "false", optional): Whether to activate debug output mode or not. Defaults to `"false"`. See [debug mode](#debug-mode) below.
 - `-t` ("true" or "false", optional): Whether to activate strict mode or not. Defaults to `"false"`. See [strict mode](#strict-mode) below.
+- `-f` ("true" or "false", optional): Whether list stacks in raw format or json format. Defaults to `"false"` which means json format. See [list raw mode](#list-in-raw-format) below.
+- `-k` (string, optional): using in action "list" is the name of an evironment variable defined on a stack.
 
 #### Examples
 
@@ -123,6 +138,10 @@ This is more suitable for standalone script usage.
 
 ```bash
 ./psu -a undeploy -u admin -p password -l http://portainer.local -n mystack
+```
+
+```bash
+./psu -a list -u admin -p password -l http://portainer.local -k TAG -f
 ```
 
 ### Stack environment variables
@@ -168,6 +187,10 @@ Debug mode can be enabled through [DEBUG_MODE envvar](#with-envvars) or [-d flag
 In strict mode the script never updates an existent stack nor removes an unexistent one, and instead exits with an error.
 
 Strict mode can be enabled through [STRICT_MODE envvar](#with-envvars) or [-t flag](#with-flags).
+
+### List in raw format
+
+when action is "list", using this switch can turn the default json output format in a raw format.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
-# Portainer Stack Utils
+# Portainer Stack Utils 
 
-[![Docker Automated build](https://img.shields.io/docker/automated/greenled/portainer-stack-utils.svg)](https://hub.docker.com/r/greenled/portainer-stack-utils/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/greenled/portainer-stack-utils.svg)](https://hub.docker.com/r/greenled/portainer-stack-utils/)
-[![Microbadger](https://images.microbadger.com/badges/image/greenled/portainer-stack-utils.svg)](http://microbadger.com/images/greenled/portainer-stack-utils "Image size")
 
-Bash script to deploy/update/undeploy stacks in a [Portainer](https://portainer.io/) instance from a [docker-compose](https://docs.docker.com/compose) [yaml file](https://docs.docker.com/compose/compose-file). Based on previous work by [@vladbabii](https://github.com/vladbabii) on [docker-how-to/portainer-bash-scripts](https://github.com/docker-how-to/portainer-bash-scripts).
+Bash script to deploy/update/undeploy and list stacks in a [Portainer](https://portainer.io/) instance from a [docker-compose](https://docs.docker.com/compose) [yaml file](https://docs.docker.com/compose/compose-file). Based on previous work by [@vladbabii](https://github.com/vladbabii) on [docker-how-to/portainer-bash-scripts](https://github.com/docker-how-to/portainer-bash-scripts).
 
 ## Supported Portainer API
 

--- a/psu
+++ b/psu
@@ -45,7 +45,27 @@ main() {
     "$PORTAINER_URL/api/stacks" \
     "Authorization: Bearer $AUTH_TOKEN")
   check_for_errors $? "$stacks"
-  echo_debug "Get stacks response -> $(echo $stacks | jq -C .)"
+  
+
+  if [ $ACTION == "list" ]; then
+     if [ $LIST_RAW_FORMAT == "true" ]; then
+      if [ $STACK_ENVVAR_NAME == "-" ]; then
+        STACKS=$(echo "$stacks" | jq -r '.[] | .Name')
+       else
+        STACKS=$(echo "$stacks" | jq --arg var $STACK_ENVVAR_NAME -r '.[] | .Name +":"+ (.Env[]| select(.name==$var).value)')
+      fi
+     else
+      if [ $STACK_ENVVAR_NAME == "-" ]; then
+         STACKS=$(echo "$stacks" | jq '.[] | {stack:.Name}' | jq -s )
+      else
+         STACKS=$(echo "$stacks" | jq --arg var $STACK_ENVVAR_NAME '.[] | {stack: (.Name), ($var):(.Env[]| select(.name==$var).value)}')
+      fi
+     fi
+     echo $STACKS
+     exit 0
+    else
+      echo_debug "Get stacks response -> $(echo $stacks | jq -C .)"
+  fi
 
   # Get desired stack from stacks list by it's name
   STACK=$(echo "$stacks" \
@@ -102,9 +122,11 @@ set_globals() {
   VERBOSE_MODE=${VERBOSE_MODE:-"false"}
   DEBUG_MODE=${DEBUG_MODE:-"false"}
   STRICT_MODE=${STRICT_MODE:-"false"}
+  STACK_ENVVAR_NAME=${STACK_ENVVAR_NAME:-"-"}
+  LIST_RAW_FORMAT=${LIST_RAW_FORMAT:-"false"}
 
   # Set arguments through flags (overwrite envvars)
-  while getopts a:u:p:l:n:c:e:g:rsvdt option; do
+  while getopts a:u:p:l:n:c:e:g:k:frsvdt option; do
     case "${option}" in
       a) ACTION=${OPTARG} ;;
       u) PORTAINER_USER=${OPTARG} ;;
@@ -114,12 +136,15 @@ set_globals() {
       c) DOCKER_COMPOSE_FILE=${OPTARG} ;;
       e) PORTAINER_ENDPOINT=${OPTARG} ;;
       g) ENVIRONMENT_VARIABLES_FILE=${OPTARG} ;;
+      k) STACK_ENVVAR_NAME=${OPTARG} ;;
+      f) LIST_RAW_FORMAT="true" ;;
       r) PORTAINER_PRUNE="true" ;;
       s) HTTPIE_VERIFY_SSL="no" ;;
       v) VERBOSE_MODE="true" ;;
       d) DEBUG_MODE="true" ;;
       t) STRICT_MODE="true" ;;
       *)
+
         echo_error "Unexpected option ${option}"
         exit 1
         ;;
@@ -140,13 +165,20 @@ set_globals() {
   echo_debug "VERBOSE_MODE -> $VERBOSE_MODE"
   echo_debug "DEBUG_MODE -> $DEBUG_MODE"
   echo_debug "STRICT_MODE -> $STRICT_MODE"
+  echo_debug "STACK_ENVVAR_NAME -> $STACK_ENVVAR_NAME"
+  echo_debug "LIST_RAW_FORMAT -> $LIST_RAW_FORMAT"
 
   # Check required arguments have been provided
   check_argument "$ACTION" "action" "ACTION" "a"
   check_argument "$PORTAINER_USER" "portainer user" "PORTAINER_USER" "u"
   check_argument "$PORTAINER_PASSWORD" "portainer password" "PORTAINER_PASSWORD" "p"
   check_argument "$PORTAINER_URL" "portainer url" "PORTAINER_URL" "l"
-  check_argument "$PORTAINER_STACK_NAME" "portainer stack name" "PORTAINER_STACK_NAME" "n"
+  if [ $ACTION != "list" ]; then
+     check_argument "$PORTAINER_STACK_NAME" "portainer stack name" "PORTAINER_STACK_NAME" "n"
+  fi
+  if [ $ACTION == "list" ]; then
+      check_argument "$STACK_ENVVAR_NAME" "env variable name to print in stack list" "STACK_ENVVAR_NAME" "k"
+  fi
   if [ $ACTION == "deploy" ]; then
     check_argument "$DOCKER_COMPOSE_FILE" "docker compose file" "DOCKER_COMPOSE_FILE" "c"
     if [ -n "$ENVIRONMENT_VARIABLES_FILE" ] && [[ ! -f "$ENVIRONMENT_VARIABLES_FILE" ]]; then

--- a/psu
+++ b/psu
@@ -58,7 +58,7 @@ main() {
       if [ $STACK_ENVVAR_NAME == "-" ]; then
          STACKS=$(echo "$stacks" | jq '.[] | {stack:.Name}' | jq -s )
       else
-         STACKS=$(echo "$stacks" | jq --arg var $STACK_ENVVAR_NAME '.[] | {stack: (.Name), ($var):(.Env[]| select(.name==$var).value)}')
+         STACKS=$(echo "$stacks" | jq --arg var $STACK_ENVVAR_NAME '.[] | {stack: (.Name), ($var):(.Env[]| select(.name==$var).value)}' | jq -s )
       fi
      fi
      echo $STACKS

--- a/psu
+++ b/psu
@@ -281,16 +281,9 @@ echo_debug() {
 deploy() {
   # Read docker-compose file content
   local docker_compose_file_content
-  docker_compose_file_content=$(cat "$DOCKER_COMPOSE_FILE")
-
-  # Remove carriage returns
-  docker_compose_file_content="${docker_compose_file_content//$'\r'/''}"
-
-  # Escape double quotes
-  docker_compose_file_content="${docker_compose_file_content//$'"'/'\"'}"
-
-  # Escape newlines
-  docker_compose_file_content="${docker_compose_file_content//$'\n'/'\n'}"
+  docker_compose_file_content="$( jq -Rscjr '{StackFileContent: . }' $DOCKER_COMPOSE_FILE | tail -c +2 | head -c -1 )"
+  echo_debug "DOCKER_COMPOSE_FILE -> $DOCKER_COMPOSE_FILE"
+  echo_debug "docker_compose_file_content -> $docker_compose_file_content"
 
   # If the stack does not exist
   if [ -z "$STACK" ]; then
@@ -324,8 +317,8 @@ deploy() {
       if [ -n "$ENVIRONMENT_VARIABLES_FILE" ]; then
         stack_envvars=$(env_file_to_json)
       fi
-      local data_prefix="{\"Name\":\"$PORTAINER_STACK_NAME\",\"StackFileContent\":\""
-      local data_suffix="\",\"Env\":"$stack_envvars"}"
+      local data_prefix="{\"Name\":\"$PORTAINER_STACK_NAME\","
+      local data_suffix=",\"Env\":"$stack_envvars"}"
       echo "$data_prefix$docker_compose_file_content$data_suffix" > json.tmp
       echo_debug "Stack JSON -> $(echo $data_prefix$docker_compose_file_content$data_suffix | jq -C .)"
 
@@ -354,8 +347,8 @@ deploy() {
       if [ -n "$ENVIRONMENT_VARIABLES_FILE" ]; then
         stack_envvars=$(env_file_to_json)
       fi
-      local data_prefix="{\"Name\":\"$PORTAINER_STACK_NAME\",\"SwarmID\":\"$swarm_id\",\"StackFileContent\":\""
-      local data_suffix="\",\"Env\":"$stack_envvars"}"
+      local data_prefix="{\"Name\":\"$PORTAINER_STACK_NAME\",\"SwarmID\":\"$swarm_id\","
+      local data_suffix=",\"Env\":"$stack_envvars"}"
       echo "$data_prefix$docker_compose_file_content$data_suffix" > json.tmp
       echo_debug "Stack JSON -> $(echo $data_prefix$docker_compose_file_content$data_suffix | jq -C .)"
 
@@ -395,8 +388,8 @@ deploy() {
       new_stack_envvars=$(env_file_to_json)
       stack_envvars="$(echo "${new_stack_envvars}${stack_envvars}" | jq -sjc 'add | unique_by(.name)')"
     fi
-    local data_prefix="{\"Id\":\"$stack_id\",\"StackFileContent\":\""
-    local data_suffix="\",\"Env\":"$stack_envvars",\"Prune\":$PORTAINER_PRUNE}"
+    local data_prefix="{\"Id\":\"$stack_id\","
+    local data_suffix=",\"Env\":"$stack_envvars",\"Prune\":$PORTAINER_PRUNE}"
     echo "$data_prefix$docker_compose_file_content$data_suffix" > json.tmp
     echo_debug "Stack JSON -> $(echo $data_prefix$docker_compose_file_content$data_suffix | jq -C .)"
 


### PR DESCRIPTION
This feature allows users to list stacks (action "list"). An optional filter based on an environment variable is available.
A typical use case is listing stacks that have an environment variable like "TAG" (or "VERSION") that identities the version. In this way user can list deployed stacks along with their own version.
By default listing is in json format. Optionally a simplier plain format is possible.